### PR TITLE
Set default image, fix navigation on hash change

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,8 +14,13 @@ window.onload = function() {
 	parser.href = window.location.href;
 
 	var imageURL = parser.hash.substring(1);
+
+	if(!imageURL) {
+		imageURL = 'servo.png';
+	}
+
 	console.log(imageURL);
-	//var imageURL = 'servo.png';
+
 	var imageWidth = 512;
 	var imageHeight = 512;
 	var imageCounter = 0;
@@ -88,4 +93,8 @@ window.onload = function() {
 	function setTransform(element, sx, sy, deg) {
 		element.style.transform = 'rotate(' + deg + 'deg) scale(' + sx + ', ' + sy + ')';
 	}
+};
+
+window.onpopstate = function(event) {
+  location.reload();
 };


### PR DESCRIPTION
If no image is specified, the default image will be used. When the URL
hash is changed, default browser behaviour is to not reload. Added a
hack to fix this.

Really feels good giving back to the valuable open source community 🤔